### PR TITLE
[Baekjoon-25757] jihoon

### DIFF
--- a/BOJ/jihoon/1week/임스와_함께하는_미니게임.cpp
+++ b/BOJ/jihoon/1week/임스와_함께하는_미니게임.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <set>
+
+using namespace std;
+
+int N; // 게임 신청 횟수
+char gType; // 게임 타입
+set<string> people; // 플레이 인원
+
+void inputPeople() {
+	cin >> N >> gType;
+	for (int i = 0; i < N; i++) {
+		string person;
+		cin >> person;
+		people.insert(person);
+	}
+}
+
+void solve() {
+	if (gType == 'Y') cout << people.size();
+	else if (gType == 'F') cout << people.size() / 2;
+	else if (gType == 'O') cout << people.size() / 3;
+}
+
+int main() {
+	ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+
+	inputPeople(); // 플레이 인원 입력
+	solve();
+
+	return 0;
+}


### PR DESCRIPTION
25757문제는 해시 알고리즘 문제로 **set 컨테이너**를 사용해야 했습니다.
set 컨테이너는 key라 불리는 원소들의 집합으로 이루어진 컨테이너인데, 원소의 중복이 허용되지 않는다는 것이 특징입니다.

해당 문제에서는 임스가 타 플레이어와 단 한번씩만 플레이할 수 있다는 것과 입력받는 플레이어가 여러번 등장하고 있습니다.
따라서 여러번 추가를 해도 중복 추가가 되지 않는 set 컨테이너를 이용하여 플레이어를 추가했습니다.

이렇게 추가한 플레이어의 수를 기준으로 게임 타입을 비교하여 임스의 총 게임 횟수를 체크하는데, 임스는 항상 게임에 참여하므로 **각 게임 타입에 참여할 수 있는 플레이어 수에서 제외하여 계산**했습니다.
위의 설명은 다음 수식으로 이어지며 문제를 해결했습니다.

> **출력값** : (임스에게 게임을 신청한 플레이어 수 = set의 size값) / (각 게임 타입에 참여할 수 있는 플레이어 수 - 1) => 몫만 출력

