### PR TITLE
[Baekjoon-2607] yein

### DIFF
--- a/BOJ/yein/2_week/[Baekjoon-2607] 비슷한 단어.py
+++ b/BOJ/yein/2_week/[Baekjoon-2607] 비슷한 단어.py
@@ -1,0 +1,17 @@
+n = int(input())
+first= sorted(input())
+cnt = 0
+    
+for _ in range(n-1):
+    first_copy = first.copy()
+    word = input()
+    err_cnt = 0
+
+    for w in word:
+        if (w in first_copy): first_copy.remove(w)
+        else: err_cnt += 1
+
+    if (err_cnt < 2 and len(first_copy)<2): cnt+=1
+    # else: print(f"{word}에서 오류 발생, {err_cnt}개의 다른 원소, {first_copy} 남음")
+
+print(cnt)


### PR DESCRIPTION
받을 문자열의 개수 n, 비교할 첫 번째 문자열 first를 입력받습니다.
cnt은 출력할 결과이며, 0으로 초기화하였습니다.

n에서 첫 번째 문자열을 제외한 횟수만큼 반복하며 비교할 새 문자열을 받습니다.
문자열의 각 문자를 순회하며, 포함된 경우 first의 복사본에서 삭제하고, 포함되지 않은 경우 err_cnt를 1 증가시키며 진행하였습니다.
이 결과, 포함되지 않은 원소 개수(err_cnt)가 1 이하이면서 first의 복사본에 남은 원소의 개수가 1 이하일 때, 비슷한 단어로 판정할 수 있다고 결론 지을 수 있었습니다.

이전에 remove 하다 메모리 초과가 난 적이 있었기에 삭제 외의 다른 방식을 사용하고 싶었으나, 이외 방법으로는 중복 문제를 해결하기 어려웠습니다...
그리고, 여러 방법을 시도해보다 처음에 first 배열을 sort하게 되었는데, 불필요한 코드 같습니다. 이 부분은 삭제하는 것이 성능이 더 나았을 것 같습니다.