### PR TITLE
[Baekjoon-1822] minji

### DIFF
--- a/BOJ/minji/2_week/차집합.py
+++ b/BOJ/minji/2_week/차집합.py
@@ -1,0 +1,11 @@
+a, b = map(int, input().split())
+a_set = set(map(int, input().split()))
+b_set = set(map(int, input().split()))
+
+difference_set = a_set - b_set
+
+if len(difference_set) > 0:
+   print(len(difference_set))
+   print(*sorted(difference_set))
+else:
+    print(0)


### PR DESCRIPTION
-집합의 차집합 계산
a_set - b_set을 통해 a_set에는 있지만 b_set에는 없는 원소들을 계산한다. 

-출력 print(*sorted(difference_set))
차집합의 원소들을 오름차순으로 정렬 후 출력한다. 출력 시 *(언팩 연산자)를 사용하였다. *을 사용하면 리스트나 튜플 등의 객체들을 개별 원소로 풀어서 출력할 수 있다.