### PR TITLE
[Baekjoon-1927] jihoon

### DIFF
--- a/BOJ/jihoon/4week/최소힙.cpp
+++ b/BOJ/jihoon/4week/최소힙.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+#include <queue>
+
+using namespace std;
+
+priority_queue<int, vector<int>, greater<int>> pq;
+
+void inputAndOutput() {
+	int N;
+	cin >> N;
+	for (int i = 0; i < N; i++) {
+		int n;
+		cin >> n;
+		if (n == 0) {
+			if (pq.empty())  cout << "0\n";
+			else {
+				cout << pq.top() << "\n";
+				pq.pop();
+			}
+		}
+		else pq.push(n);
+	}
+}
+
+void solve() {
+	inputAndOutput();
+}
+
+int main() {
+	ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+
+	solve();
+
+	return 0;
+}


### PR DESCRIPTION
1927 문제는 우선순위 큐 문제입니다.
우선순위 큐는 큐에 값을 넣을 때마다 최댓값이 가장 상단 노드에 위치하게 되고, top을 pop하면 그 다음 최댓값 노드가 루트 노드가 되는 자료구조입니다.
하지만 이 문제는 max heap이 아닌 min heap 문제이므로, 큐의 비교 연산자를 less<int>가 아닌 greater<int>를 사용하여 최솟값 노드가 루트 노드가 되게 합니다.

출력 형식은 n이 0일 때, 큐가 비어있다면 0 출력, 아니라면 pq 루트 노드 출력 후 루트 노드를 제거 해주면 됩니다.