### PR TITLE
[Baekjoon-17484] 타임어택 문제풀이

### DIFF
--- a/BOJ/jihoon/4week/진우의_달_여행_(Small).cpp
+++ b/BOJ/jihoon/4week/진우의_달_여행_(Small).cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <algorithm>
+#include <climits>
+
+using namespace std;
+
+int N, M, minOil = INT_MAX;
+int space[7][7];
+int dx[3] = { -1, 0, 1 };
+
+// col는 열의 위치, row는 행의 위치, sum은 현재까지의 연료 소비량, dir은 현재 이동 방향
+void dfs(int col, int row, int sum, int dir) {
+    sum += space[row][col];  // 현재 위치 연료 소비량 추가
+
+    // 마지막 행에 도착한 경우
+    if (row == N - 1) {
+        minOil = min(minOil, sum);
+        return;
+    }
+
+    // 3가지 방향으로 이동
+    for (int i = 0; i < 3; i++) {
+        if (i == dir) continue;
+
+        int nx = col + dx[i];
+
+        // 열을 벗어나는 경우 패스
+        if (nx < 0 || nx >= M) continue;
+
+        dfs(nx, row + 1, sum, i);
+    }
+}
+
+int main() {
+    ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+
+    cin >> N >> M;
+    for (int i = 0; i < N; i++)
+        for (int j = 0; j < M; j++)
+            cin >> space[i][j];
+
+    // 각 열에서 출발할 수 있도록 설정
+    for (int i = 0; i < M; i++) {
+        // 첫방향은 -1로 무의미한 방향 설정
+        dfs(i, 0, 0, -1);
+    }
+
+    cout << minOil << "\n";
+
+    return 0;
+}


### PR DESCRIPTION
17484는 두 가지의 풀이법이 있습니다.
1. dp
2. dfs
저는 우주 보드의 최대 칸이 겨우 6*6밖에 안되기 때문에 dfs로 풀었습니다. 시간복잡도는 첫 위치에서 N번 위치까지 가는데 3^(N-1)의 복잡도가 필요하고 해당 반복을 첫 위치를 M번 정하므로 총 O(M * 3^(N-1)) 입니다. 하지만 M,N의 최댓값이 6이므로 최대 6 * 3^5 = 1458번 밖에 반복하지 않기에 충분히 dfs로 가능한 문제입니다. 단, 3의 19 제곱은 약 11억 정도니까 N, M이 19까지 늘어나면 1초 안에 절대 안된다는,,,

그래서 dfs로 설정했고, 인자값은 4개로 col는 열의 위치, row는 행의 위치, sum은 현재까지의 연료 소비량, dir은 현재 이동 방향으로 설정했습니다. 마지막 행 도착 조건 및 3가지 이동 방향에 따른 dx값 설정은 기본적인 dfs 설정으로 진행했습니다.

그리고 골치 아팠던 것은 조건 2었는데, 이걸 안보고 풀어서 계속 틀렸었습니다.. 이전에 진행한 방향은 진행하면 안되기 때문에 dir 값을 받아서 3가지 이동 방향 중에 dir과 동일한 방향은 이동하지 않도록 했습니다.
또한, 첫 이동 방향은 제한되면 안되므로 첫 dir은 -1로 설정해서 예외를 처리했습니다.

교훈: 문제를 꼼꼼히 읽자