### PR TITLE
[Baekjoon-17484] 타임어택 문제풀이

### DIFF
--- a/BOJ/jihoon/4week/진우의_달_여행_(Small).cpp
+++ b/BOJ/jihoon/4week/진우의_달_여행_(Small).cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <algorithm>
+#include <climits>
+
+using namespace std;
+
+int N, M, minOil = INT_MAX;
+int space[7][7];
+int dx[3] = { -1, 0, 1 };
+
+// col는 열의 위치, row는 행의 위치, sum은 현재까지의 연료 소비량, dir은 현재 이동 방향
+void dfs(int col, int row, int sum, int dir) {
+    sum += space[row][col];  // 현재 위치 연료 소비량 추가
+
+    // 마지막 행에 도착한 경우
+    if (row == N - 1) {
+        minOil = min(minOil, sum);
+        return;
+    }
+
+    // 3가지 방향으로 이동
+    for (int i = 0; i < 3; i++) {
+        if (i == dir) continue;
+
+        int nx = col + dx[i];
+
+        // 열을 벗어나는 경우 패스
+        if (nx < 0 || nx >= M) continue;
+
+        dfs(nx, row + 1, sum, i);
+    }
+}
+
+int main() {
+    ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+
+    cin >> N >> M;
+    for (int i = 0; i < N; i++)
+        for (int j = 0; j < M; j++)
+            cin >> space[i][j];
+
+    // 각 열에서 출발할 수 있도록 설정
+    for (int i = 0; i < M; i++) {
+        // 첫방향은 -1로 무의미한 방향 설정
+        dfs(i, 0, 0, -1);
+    }
+
+    cout << minOil << "\n";
+
+    return 0;
+}

--- a/BOJ/jihoon/4week/진우의_달_여행_(Small).cpp
+++ b/BOJ/jihoon/4week/진우의_달_여행_(Small).cpp
@@ -1,3 +1,5 @@
+/* DFS 풀이 */
+
 #include <iostream>
 #include <algorithm>
 #include <climits>
@@ -43,6 +45,79 @@ int main() {
     for (int i = 0; i < M; i++) {
         // 첫방향은 -1로 무의미한 방향 설정
         dfs(i, 0, 0, -1);
+    }
+
+    cout << minOil << "\n";
+
+    return 0;
+}
+
+
+/* DP 풀이 */
+
+#include <iostream>
+#include <algorithm>
+#include <climits>
+
+using namespace std;
+
+int N, M;
+int space[7][7];
+long long dp[7][7][3]; // 각 위치까지의 최소 연료량을 담는 dp -> INT_MAX + 연료 연산을 오버 플로우 방지로 long long 타입
+int dx[3] = { -1, 0, 1 };
+
+// dp 채우기
+void fill_dp() {
+    for (int i = 1; i < N; i++) {
+        for (int j = 0; j < M; j++) {
+            for (int dir = 0; dir < 3; dir++) { // 진행할 다음 방향
+                int prev_col = j - dx[dir]; // 이전 열(이동 전)
+                if (prev_col < 0 || prev_col >= M) continue;
+
+                // 이전 행에서 진행한 방향과 다른 방향으로 전진
+                for (int prev_dir = 0; prev_dir < 3; prev_dir++) {
+                    if (prev_dir == dir) continue; // 이전 행에서 진행한 방향과 현재 위치에서 진행할 방향이 같으면 안됨
+
+                    // 진행할 다음 방향 = min(진행할 다음 방향에 기록된 누적 연료, 이동 전 위치에서의 prev_dir 진행 방향의 누적 연료 + 이동할 위치에서 필요한 연료)
+                    dp[i][j][dir] = min(dp[i][j][dir], dp[i - 1][prev_col][prev_dir] + space[i][j]);
+                }
+            }
+        }
+    }
+}
+
+// dp 초기값 설정
+void dp_init() {
+    for (int i = 0; i < M; i++) {
+        for (int j = 0; j < 3; j++) {
+            dp[0][i][j] = space[0][i];
+        }
+    }
+}
+
+int main() {
+    ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+
+    cin >> N >> M;
+    // 연료 입력 및 dp 초기화
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < M; j++) {
+            cin >> space[i][j];
+            for (int k = 0; k < 3; k++) {
+                dp[i][j][k] = INT_MAX; // 최댓값으로 기본 설정
+            }
+        }
+    }
+
+    dp_init();
+    fill_dp();
+
+    // 최소 연료 출력
+    long long minOil = INT_MAX;
+    for (int j = 0; j < M; j++) {
+        for (int k = 0; k < 3; k++) {
+            minOil = min(minOil, dp[N - 1][j][k]);
+        }
     }
 
     cout << minOil << "\n";


### PR DESCRIPTION
17484는 두 가지의 풀이법이 있습니다.

1. dp
2. dfs

저는 우주 보드의 최대 칸이 겨우 6*6밖에 안되기 때문에 dfs로 풀었습니다. 시간복잡도는 첫 위치에서 N번 위치까지 가는데 3^(N-1)의 복잡도가 필요하고 해당 반복을 첫 위치를 M번 정하므로 총 O(M * 3^(N-1)) 입니다. 하지만 M,N의 최댓값이 6이므로 최대 6 * 3^5 = 1458번 밖에 반복하지 않기에 충분히 dfs로 가능한 문제입니다. 단, 3의 19 제곱은 약 11억 정도니까 N, M이 19까지 늘어나면 1초 안에 절대 안된다는,,,
그래서 dfs로 설정했고, 인자값은 4개로 col는 열의 위치, row는 행의 위치, sum은 현재까지의 연료 소비량, dir은 현재 이동 방향으로 설정했습니다. 마지막 행 도착 조건 및 3가지 이동 방향에 따른 dx값 설정은 기본적인 dfs 설정으로 진행했습니다.

그리고 골치 아팠던 것은 조건 2었는데, 이걸 안보고 풀어서 계속 틀렸었습니다.. 이전에 진행한 방향은 진행하면 안되기 때문에 dir 값을 받아서 3가지 이동 방향 중에 dir과 동일한 방향은 이동하지 않도록 했습니다.
또한, 첫 이동 방향은 제한되면 안되므로 첫 dir은 -1로 설정해서 예외를 처리했습니다.

----

이후에 dp를 사용한 풀이도 추가했습니다.
dp를 사용하면 O(N*M) 복잡도로 훨씬 빠르게 줄어듭니다.

구현은 먼저 dp 배열을 3차원 배열으로 N * M * 3 형태로 했습니다. 3은 이동 방향에 대한 설정입니다. (i, j) 위치에 대해서 들어온 방향에 대한 연료 누적값을 저장합니다.

초기화는 모두 INT_MAX로 최댓값으로 지정한 뒤, 첫번째 행에 대해서만 연료값을 모두 첫 연료값으로 설정합니다.
이때, INT_MAX에 다음 연료값을 더한 값을 비교하는 상황이 오기때문에 오버플로우 발생이 일어나 dp는 long long 타입으로 지정합니다.
그리고 dp를 채우는데, 현재 위치에서 이동할 방향과 이전 위치에서 이동한 방향을 비교해서 같은 방향은 제외하고 이동할 방향에 대해 dp 값을 새롭게 채워넣습니다. (이전 위치의 열 값은 현재 열에서 이동할 방향의 dx값을 뺀 값으로 설정 -> 그래야 방향이 겹치지 않는 열로 설정 가능)

이렇게 채워넣은 dp값의 마지막 행에서 최솟값을 구하면 끝입니다.

---

교훈: 문제를 꼼꼼히 읽자