### PR TITLE
[Baekjoon-2164] minji

### DIFF
--- a/BOJ/minji/5_week/카드2.py
+++ b/BOJ/minji/5_week/카드2.py
@@ -1,0 +1,29 @@
+'''
+#런타임 오류 발생 코드
+card_list = []
+n = int(input())
+
+for i in range(n):
+    card_list.append(i+1)
+
+while(len(card_list) != 1):
+    del card_list[0]
+    card_list.append(card_list[0])
+    del card_list[0]
+
+print(*card_list)         
+'''
+
+from collections import deque
+
+n = int(input())  
+card_list = deque(range(1, n+1)) 
+
+while len(card_list) > 1:
+    card_list.popleft()  
+    card_list.append(card_list.popleft())  
+
+print(*card_list) 
+
+                            
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                


### PR DESCRIPTION
처음에는 카드가 한 장만 남을 때까지 리스트를 사용해서 첫 번째 원소를 제거, 추가하는 연산을 반복하였습니다. 리스트에서 0번째 인덱스의 값을 제거하는 연산은 그 뒤의 모든 원소들을 한 칸씩 앞으로 당겨야 하기 때문에 O(n) 시간이 걸립니다. 처음 작성한 코드에서는 시간 복잡도가 O(n^2) 이 나와 런타임 오류가 발생하였습니다. 

파이썬의 덱 자료구조를 이용하여 문제를 해결하였습니다. 덱 자료구조를 사용하면 원소를 삭제하거나 추가하는 연산이 O(1)이기 때문에 런타임 오류를 해결할 수 있었습니다.