### PR TITLE
[Baekjoon-1931] minji

### DIFF
--- a/BOJ/minji/5_week/회의실 배정.py
+++ b/BOJ/minji/5_week/회의실 배정.py
@@ -1,0 +1,22 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+
+time_list = []
+
+for i in range(n):
+    time_list.append(list(map(int, input().split())))
+
+#끝나는 시간을 기준으로 정렬
+time_list.sort(key=lambda x: (x[1], x[0]))
+
+count = 0 
+last_end = 0  
+
+#회의가 겹치지 않으면 선택
+for start, end in time_list:
+    if start >= last_end:
+        count += 1
+        last_end = end 
+print(count)


### PR DESCRIPTION
회의가 빨리 끝날수록 더 많은 회의를 배치할 수 있기 때문에 회의가 끝나는 시간을 기준으로 정렬합니다. 

반복문을 돌면서 현재 회의의 시작 시간이 이전 회의의 끝나는 시간보다 크거나 같으면 그 회의를 선택합니다. 
회의가 선택 되면 count값을 1 증가 시키고, 끝나는 시간을 담은 end_time 변수도 업데이트 해줍니다. 

처음에는 회의들을 끝나는 시간 기준으로만 정렬하였는데, 채점 결과가 틀렸다고 나왔습니다. 틀린 이유는 끝나는 시간이 같으면 시작 시간이 빠른 순으로 정렬했어야 했는데 이를 고려하지 못해서 틀렸습니다. 정렬할 때 여러 기준을 동시에 정렬하는 문법을 몰라서 찾아 봤습니다. lamda 함수에서 튜플을 반환하여 정렬 기준을 복수로 지정할 수 있다는 것을 배웠습니다.

`time_list.sort(key=lambda x: (x[1], x[0]))`