### PR TITLE
[Baekjoon-1931] jihoon

### DIFF
--- a/BOJ/jihoon/5week/회의실_배정.cpp
+++ b/BOJ/jihoon/5week/회의실_배정.cpp
@@ -1,0 +1,41 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int N;
+vector<pair<int, int>> roomTime;
+
+// 참여가능한 회의실 개수 세기
+int roomCnt() {
+	int count = 0, endTime = 0;
+	for (int i = 0; i < N; i++) {
+		if (endTime <= roomTime[i].first) {
+			count++;
+			endTime = roomTime[i].second;
+		}
+	}
+	return count;
+}
+
+// 끝 시간 오름차순 정렬 -> 끝시간 같다면 시작 시간 오름차순 정렬
+bool cmp(pair<int, int> t1, pair<int, int> t2) {
+	if (t1.second == t2.second) return t1.first < t2.first;
+	return t1.second < t2.second;
+}
+
+int main() {
+	ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+
+	cin >> N;
+	for (int i = 0; i < N; i++) {
+		int s, e;
+		cin >> s >> e;
+		roomTime.push_back({ s,e });
+	}
+
+	sort(roomTime.begin(), roomTime.end(), cmp);
+
+	cout << roomCnt();
+
+	return 0;
+}


### PR DESCRIPTION
1931 문제는 정렬과 그리디 문제입니다.
회의가 끝나야 다음 회의를 시작할 수 있습니다. 따라서 회의가 최대한 빨리 끝날 수록 시작할 수 있는 회의가 많아지게 됩니다.

그렇게 때문에 회의가 끝나는 시간을 기준으로 오름차순으로 정렬합니다. 단, 이때 끝나는 시간이 같은 경우를 처리해줘야 한다.

예를 들면, 회의 A의 시작 시간이 1이고 끝나는 시간은 2, 회의 B의 시작 시간은 2이고 끝나는 시간은 2라고 하겠습니다.
원래라면 A를 선택하고 B를 선택해야 총 2개 선택으로 해답이 됩니다. (1-2 / 2-2 이기 때문)
그런데 시작 시간을 오름차순 정렬하지 않아서, B를 먼저 선택하게 된다면, (2-2 / 1-2(선택불가))로 A를 선택할 수 없어 회의실은 1개밖에 선택할 수 없습니다.

따라서 정렬 조건은 끝 시간 오름차순 정렬 -> 끝시간이 같다면 시작 시간 오름차순 정렬로 합니다.
이렇게 하고 반복문을 돌려 끝시간을 업데이트하며 선택하면 답에 도달합니다.

----
참고: 시간 벡터가 pair(시작 시간, 끝 시간) 으로 들어있는데, pair(끝 시간, 시작 시간)으로 넣고, 그냥 sort하면 알아서 위와 같은 정렬을 해주기 때문에, 커스텀 정렬은 하지 않아도 됩니다.