### PR TITLE
[Baekjoon-19941] 타임어택 문제 풀이

### DIFF
--- a/BOJ/jihoon/5week/햄버거_분배.cpp
+++ b/BOJ/jihoon/5week/햄버거_분배.cpp
@@ -1,0 +1,45 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int N, K;
+int arr[20000];
+vector<int> ppos;
+
+int findBurger() {
+	int resultCnt = 0;
+
+	for (int i = 0; i < ppos.size(); i++) {
+		// 왼쪽 최대 거리부터 오른쪽 최대 거리까지 햄버거 찾기
+		for (int s = max(ppos[i] - K, 0); s <= min(ppos[i] + K, N - 1); s++) {
+			// 햄버거를 찾았다면 먹고 break
+			if (arr[s] == 2) {
+				resultCnt++;
+				arr[s] = 0;
+				break;
+			}
+		}
+	}
+
+	return resultCnt;
+}
+
+int main() {
+	ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+
+	cin >> N >> K;
+	string str;
+	cin >> str;
+	for (int i = 0; i < str.length(); i++) {
+		// 사람인 경우 1, 햄버거인 경우 2 저장
+		if (str[i] == 'P') {
+			arr[i] = 1;
+			ppos.push_back(i);
+		}
+		else arr[i] = 2;
+	}
+
+	cout << findBurger();
+
+	return 0;
+}


### PR DESCRIPTION
19941 문제는 그리디 문제입니다.

처음에는 사람이 있는 위치마다 dfs로 왼쪽부터 탐색해서 찾는 순간 탈출을 하는 방법으로 풀다가, 그럴 이유 없이 각 위치에서 왼쪽 최대 거리부터 오른쪽 최대 거리까지 탐색하며 햄버거를 찾으면 된다는 것을 깨달았습니다.

따라서 왼쪽으로 갈 수 있는 최대 위치 -> 오른쪽으로 갈 수 있는 최대 위치로 탐색하며 햄버거를 찾는 순간 해당 위치는 먹었다는 표시로 0으로 설정하고 다른 사람의 위치에서 시작해서 다시 탐색하는 식으로 문제를 해결했습니다.