### PR TITLE
[Baekjoon-1202] jihoon

### DIFF
--- a/BOJ/jihoon/9week/보석_도둑.cpp
+++ b/BOJ/jihoon/9week/보석_도둑.cpp
@@ -1,0 +1,54 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int N, K;
+vector<pair<int, int>> info; // 보석의 무게와 가격 정보
+vector<int> bag; // 가방 정보
+
+void input() {
+	cin >> N >> K;
+	for (int i = 0; i < N; i++) {
+		int m, v;
+		cin >> m >> v;
+		info.push_back({ m, v });
+	}
+	for (int i = 0; i < K; i++) {
+		int c;
+		cin >> c;
+		bag.push_back(c);
+	}
+}
+
+int main() {
+	ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+	long long result = 0;
+
+	input();
+	// 보석 -> 무게 오름차순
+	// 가방 -> 오름차순
+	sort(info.begin(), info.end());
+	sort(bag.begin(), bag.end());
+
+	priority_queue<int> pq; // 담을 수 있는 보석을 담을 pq
+	int idx = 0; // 현재까지 탐색한 보석 개수
+
+	// 각 가방마다 확인
+	for (int i = 0; i < K; i++) {
+		// i번째 가방에 담을 수 있는 보석을 모두 pq에 추가
+		while (idx < info.size() && bag[i] >= info[idx].first) {
+			pq.push(info[idx].second);
+			idx++;
+		}
+
+		// 큐에 보석이 담겨 있다면 가격이 가장 높은 보석 추가
+		if (!pq.empty()) {
+			result += pq.top();
+			pq.pop();
+		}
+	}
+
+	cout << result;
+
+	return 0;
+}


### PR DESCRIPTION
1202 문제는 정렬과 우선순위 큐로 풀었습니다.

예전에 한번 풀었던 문제였지만 하나도 기억이 나지 않아서 고민을 꽤 했습니다..
처음에는 각 가방에 대해서 무게와 가격을 어떻게 정렬해서 넣을지 생각했습니다. 매번 정렬을 하거나 무게와 가격에 대한 커스텀 우선순위 큐를 사용하기에는 가방이 총 1억개와 보선이 30만개가 존재해 최악의 경우 3천억번이 일어날 것이라고 생각하여 이 방법은 아닌 것 같았습니다.

그러면 이 정도 연산을 단 1초 만에 해내야 하니 단 한번의 정렬으로 해결해야 하는구나 했습니다.
따라서 가방은 먼저 가장 작은 가방부터 처리해야 나중에 보석을 넣을 자유도가 올라가므로 오름차순 정렬을 했습니다.
그리고 보석 정보를 담은 배열은 무게순으로 오름차순 정렬을 했습니다.

각 가방마다 반복문을 진행하고 해당 가방에 들어갈 수 있는 무게를 가진 모든 보석을 우선순위 큐에 담습니다.
가능한 보석이 모두 담겼다면, 우선순위 큐의 top 노드를 꺼내 가방에 넣습니다.
그리고 남은 보석은 다음 가방에 넣을 보석으로 취급하여 다음 가방에 대해서 다시 탐색을 시작합니다.

이렇게 하여 모든 가방에 대해서 최적의 보석을 넣을 수 있었습니다.