### PR TITLE
[Baekjoon-1863] 타임어택 문제풀이

### DIFF
--- a/BOJ/jihoon/9week/스카이라인_쉬운거.cpp
+++ b/BOJ/jihoon/9week/스카이라인_쉬운거.cpp
@@ -1,0 +1,45 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int n, result;
+vector<pair<int, int>> v;
+stack<int> st;
+
+int main() {
+	ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+	cin >> n;
+	for (int i = 0; i < n; i++) {
+		int x, y;
+		cin >> x >> y;
+		v.push_back({ x, y });
+	}
+
+	sort(v.begin(), v.end());
+
+	for (int i = 0; i < n; i++) {
+		int num = v[i].second;
+
+		// 담는 수가 top보다 작으면
+		// 건물수 증가 후 pop
+		// 반복
+		while (!st.empty() && st.top() > num) {
+			result++;
+			st.pop();
+		}
+		// top보다 크거나 비어있으면 추가
+		if (st.empty() || st.top() < num) {
+			if (num > 0) st.push(num);
+		}
+	}
+
+	// 모두 끝난 후 st에 들어있는 수만큼 건물 증가
+	while (!st.empty()) {
+		result++;
+		st.pop();
+	}
+
+	cout << result;
+
+	return 0;
+}


### PR DESCRIPTION
1863번 문제는 스택으로 풀었습니다.

먼저 입력으로 받는 x,y가 x에 대해서 오름차순 정렬이 보장되어 있지 않기 때문에 오름차순 정렬부터 해줍니다.
그리고 빌딩의 정보를 순차적으로 돌며 스택에 담고 빼며 빌딩의 개수를 판단합니다.
스택이 비어있지 않다고 top이 현재 들어오는 빌딩 높이보다 크다면 스택에 들어있던 빌딩의 높이는 더이상 유지되지 않는다는 의미이기 때문에 빌딩을 추가하고 스택에서 빼줍니다.
이때 중요한 것은 빼고 나서도 현재 추가되는 빌딩의 높이보다 큰 수가 top에 있을 수 있기 때문에 해당 과정을 while문을 통해 진행합니다.

그렇게 while문이 종료되고 나면 현재 판단하는 빌딩이 추가될 빌딩인지 판단합니다.
만약 스택이 비어있다면, 바로 스택에 추가합니다.
또는 스택의 top이 추가하려는 빌딩의 높이보다 작다면 이전 빌딩은 유지되고 현재 추가하는 빌딩은 담길 수 있기 때문에 스택에 추가합니다.
여기서 스택에 추가하려는 빌딩의 높이는 0보다 커야합니다. -> 입력되는 빌딩의 높이가 0도 가능하기 때문

입력된 빌딩들에 대해서 전부 판단하고 나면 스택에 들어있는 빌딩이 있을 수 있습니다.
스택에 빌딩이 남아있다는 것은 해당 빌딩은 아직 추가되지 않았다는 것이므로 while문을 통해서 스택이 비어있을 때까지 스택을 비우며 빌딩을 추가합니다. 이때 스택에 들어가는 빌딩은 중복이 없으므로 그냥 빼면 됩니다.

마지막으로 빌딩의 수를 출력하면 끝입니다.