### PR TITLE
[Baekjoon-15683] jihoon

### DIFF
--- a/BOJ/jihoon/10week/감시.cpp
+++ b/BOJ/jihoon/10week/감시.cpp
@@ -1,0 +1,112 @@
+﻿#include <bits/stdc++.h>
+
+using namespace std;
+
+int N, M;
+vector<pair<int, int>> cctv;
+int arr[8][8];
+
+int result = INT_MAX;
+
+// 상 우 하 좌
+int dx[4] = { 0, 1, 0, -1 };
+int dy[4] = { -1, 0, 1, 0 };
+
+void check0(int x, int y, int d) {
+	// d 방향으로 벽이나 끝지점 도달까지 탐색
+	while (1) {
+		x += dx[d];
+		y += dy[d];
+
+		if (x < 0 || x >= N || y < 0 || y >= M) return;
+		if (arr[x][y] == 6) return;
+		if (arr[x][y] != 0) continue; // cctv인 경우
+		arr[x][y] = -1; // 탐색 표시
+	}
+}
+
+// idx는 cctv 배열의 인덱스값
+void dfs(int idx) {
+	// 모든 cctv에 대해서 탐색을 마친 경우 result 갱신
+	if (idx == cctv.size()) {
+		int cnt = 0;
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < M; j++) {
+				if (arr[i][j] == 0) cnt++;
+			}
+		}
+		result = min(result, cnt);
+		return;
+	}
+
+	// cctv의 x, y좌표에 대해서
+	// arr[x][y]의 값으로 어느 방향으로 갈지 판단
+	int x = cctv[idx].first;
+	int y = cctv[idx].second;
+	int tmp[8][8] = { 0, };
+
+	// d는 현재 가리키고 있는 방향
+	for (int d = 0; d < 4; d++) {
+		// 나아가는 방향에 대해서
+		// arr을 업데이트할 것이므로 기존 값 담을 tmp
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < M; j++) {
+				tmp[i][j] = arr[i][j];
+			}
+		}
+
+		if (arr[x][y] == 1) { // 1번 cctv
+			check0(x, y, d % 4);
+		}
+		else if (arr[x][y] == 2) { // 2번 cctv
+			// 0도 180도
+			check0(x, y, d % 4);
+			check0(x, y, (d + 2) % 4);
+		}
+		else if (arr[x][y] == 3) { // 3번 cctv
+			// 0도 90도
+			check0(x, y, d % 4);
+			check0(x, y, (d + 1) % 4);
+		}
+		else if (arr[x][y] == 4) { // 4번 cctv
+			// 0도 90도 180도
+			check0(x, y, d % 4);
+			check0(x, y, (d + 1) % 4);
+			check0(x, y, (d + 2) % 4);
+		}
+		else if (arr[x][y] == 5) { // 5번 cctv
+			// 0도 90도 180도 270도
+			check0(x, y, d % 4);
+			check0(x, y, (d + 1) % 4);
+			check0(x, y, (d + 2) % 4);
+			check0(x, y, (d + 3) % 4);
+		}
+
+		// 해당 cctv의 0체크가 모두 끝나면 다음 cctv 탐색
+		dfs(idx + 1);
+		// 탐색 종료되면 arr 원복
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < M; j++) {
+				arr[i][j] = tmp[i][j];
+			}
+		}
+	}
+}
+
+int main() {
+	ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+	cin >> N >> M;
+	for (int i = 0; i < N; i++) {
+		for (int j = 0; j < M; j++) {
+			cin >> arr[i][j];
+			if (arr[i][j] != 0 && arr[i][j] != 6) {
+				cctv.push_back({ i,j });
+			}
+		}
+	}
+
+	dfs(0); // 0번째 cctv부터 시작
+	cout << result;
+
+	return 0;
+}


### PR DESCRIPTION
15683 문제는 구현(dfs & 방향 시뮬레이션)로 풀었는데, 쉽지 않아서 결국 정답을 찾아서 참고하여 풀었습니다..

먼저 각 cctv마다 회전의 경우의 수를 따져줘야 했기 때문에 모든 경우의 수를 탐색했어야 했습니다. 그를 위해서는 각 cctv마다 가능한 회전의 경우의 수만큼 체크하고 다음 cctv로 넘어간 뒤, 또 그 cctv의 회전 경우의 수를 모두 탐색해야 했습니다.

cctv마다 늘어가는 depth는 dfs로 늘려갔습니다. 따라서 반복 횟수가 cctv.size() 만큼 도달하면 사각지대 개수를 갱신하고 dfs를 종료합니다.
각 dfs마다는 cctv의 회전들을 탐색하는데, 1,2,3,4,5 유형의 cctv마다 방향 값을 따로 지정해줍니다. 방향 값은 고정하되 회전을 총 상하좌우로 반복해주며 check0 함수에 들어가서 해당 방향으로 쭉 진행하며 0을 탐색합니다.

=> 코드에서는 귀찮기도 하고 시간도 충분했기에 전부 회전을 4번 해줬지만, 각 cctv마다 4,2,4,1 번의 경우의 수로 나눠서 반복횟수를 줄이는게 좋을 것 같습니다.

이렇게 해서 dfs 맨 마지막에 0의 개수만 세서 계속 갱신해주면 최소의 사각 지대 수가 반환됩니다.