### PR TITLE
[Programmers-타겟 넘버] jihoon

### DIFF
--- a/PGS/10week/타겟 넘버.cpp
+++ b/PGS/10week/타겟 넘버.cpp
@@ -1,0 +1,60 @@
+﻿/*** DFS 풀이 ***/
+
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int answer = 0;
+void dfs(vector<int> numbers, int target, int idx, int sum) {
+    if (idx == numbers.size()) { // 끝에 도달
+        if (sum == target) { // target 완성
+            answer++;
+        }
+        return;
+    }
+
+    dfs(numbers, target, idx + 1, sum + numbers[idx]); // +1
+    dfs(numbers, target, idx + 1, sum - numbers[idx]); // -1
+}
+
+int solution(vector<int> numbers, int target) {
+
+    dfs(numbers, target, 0, 0);
+
+    return answer;
+}
+
+
+/*** BFS 풀이 ***/
+
+/*
+#include <vector>
+#include <queue>
+
+using namespace std;
+
+int solution(vector<int> numbers, int target){
+    int answer = 0;
+    queue<int> Q;
+    Q.push(numbers[0]);
+    Q.push(-1 * numbers[0]);
+
+    for(int i=1; i<numbers.size(); i++){
+        int len = Q.size();
+        for(int j=0; j<len; j++){
+            int sum = Q.front();
+            Q.pop();
+            Q.push(sum + numbers[i]);
+            Q.push(sum - numbers[i]);
+        }
+    }
+    int len = Q.size();
+    for(int i=0; i<len; i++){
+        if(Q.front() == target)
+            answer++;
+        Q.pop();
+    }
+
+    return answer;
+}
+*/


### PR DESCRIPTION
타겟 넘버는 dfs나 bfs로 풀 수 있는 문제입니다.
문제에 들어가보니 이전에 bfs로 푼 흔적이 있어서 이번에는 dfs로 풀어봤습니다.

dfs는 dfs(숫자 배열, 타겟 값, 다음 인덱스, 현재까지 합)으로 구성하고 재귀를 반복했습니다. 그리고 각 dfs마다 idx에 대해서 sum + numbers[idx], sum - numbers[idx]로 두번의 dfs로 depth를 늘렸습니다.

이후 idx == numbers.size()가 되어 끝 지점에 도달하면 종료하고, sum이 target에 도달했다면 answer를 1 증가시키며 문제를 해결합니다.