### PR TITLE
[Baekjoon-16234] jihoon

### DIFF
--- a/BOJ/jihoon/11week/인구이동.cpp
+++ b/BOJ/jihoon/11week/인구이동.cpp
@@ -1,0 +1,82 @@
+#include <bits/stdc++.h>
+
+using namespace std;
+
+int N, L, R;
+int world[50][50];
+bool visited[50][50];
+
+int day = 0;
+
+int dx[4] = { -1,1,0,0 };
+int dy[4] = { 0,0,-1,1 };
+
+bool bfs(int x, int y) {
+	bool check = false;
+	int sum = world[x][y];
+
+	queue<pair<int, int>> group; // 연합
+	queue<pair<int, int>> q;
+
+	q.push({ x,y });
+	group.push({ x,y });
+	visited[x][y] = true;
+
+	while (!q.empty()) {
+		int xpos = q.front().first;
+		int ypos = q.front().second;
+		q.pop();
+
+		for (int i = 0; i < 4; i++) {
+			int nx = xpos + dx[i];
+			int ny = ypos + dy[i];
+
+			if (nx < 0 || nx >= N || ny < 0 || ny >= N || visited[nx][ny]) continue;
+
+			if (abs(world[xpos][ypos] - world[nx][ny]) >= L && abs(world[xpos][ypos] - world[nx][ny]) <= R) {
+				q.push({ nx, ny });
+				group.push({ nx,ny });
+				sum += world[nx][ny];
+				visited[nx][ny] = true;
+				check = true; // 연합 생성
+			}
+		}
+	}
+
+	int avg = sum / group.size();
+	while (!group.empty()) {
+		world[group.front().first][group.front().second] = avg;
+		group.pop();
+	}
+
+	return check;
+}
+
+int main() {
+	ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+
+	cin >> N >> L >> R;
+	for (int i = 0; i < N; i++) {
+		for (int j = 0; j < N; j++) {
+			cin >> world[i][j];
+		}
+	}
+
+	bool check = true;
+	while (check) {
+		check = false;
+		memset(visited, false, sizeof(visited));
+
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < N; j++) {
+				// 연합이 형성되면 check를 true로
+				if (!visited[i][j] && bfs(i, j)) check = true;
+			}
+		}
+		if (check) day++;
+	}
+
+	cout << day;
+
+	return 0;
+}


### PR DESCRIPTION
16234번 문제는 bfs를 반복 체크하는 문제입니다.

연합이 생기지 않을 때까지 계속 bfs를 시도하게 됩니다. 이때, bfs는 연합이 생겼는지에 대한 유무를 반환합니다.
bfs는 두가지 큐에 연합을 저장하는데, 하나는 bfs로 소모되는 큐, 하나는 연합으로 유지되는 큐로 구성합니다.
큐는 규격을 벗어나는지, 방문한 곳인지 체크를 진행하며 탐색하고, L이상 R이하라면 연합을 구성하도록합니다.
그리고 구성된 연합은 평균 인구수로 모두 동일하게 업데이트합니다.

이렇게 반복하다 보면 인구수가 맞춰져 종료하게 됩니다.