### PR TITLE
[Baekjoon-2606] jihoon

### DIFF
--- a/BOJ/jihoon/13week/바이러스.cpp
+++ b/BOJ/jihoon/13week/바이러스.cpp
@@ -1,0 +1,50 @@
+﻿#include <bits/stdc++.h>
+
+using namespace std;
+
+int N;
+int con;
+int network[101][101];
+bool visited[101];
+int cnt = 0;
+
+int main() {
+	ios_base::sync_with_stdio(0); cin.tie(0); cout.tie(0);
+
+	cin >> N >> con;
+	for (int i = 0; i < con; i++) {
+		int n1, n2;
+		cin >> n1 >> n2;
+		network[n1][n2] = 1;
+		network[n2][n1] = 1;
+	}
+
+	queue<int> q;
+	visited[1] = true;
+	for (int i = 2; i <= N; i++) {
+		if (network[1][i] == 1) {
+			q.push(i);
+			visited[i] = true;
+			cnt++;
+		}
+	}
+
+	while (!q.empty()) {
+		int n = q.front();
+		q.pop();
+
+		for (int i = 1; i <= N; i++) {
+			if (i == n) continue;
+
+			if (network[n][i] == 1 && !visited[i]) {
+				q.push(i);
+				visited[i] = true;
+				cnt++;
+			}
+		}
+	}
+
+	cout << cnt;
+
+	return 0;
+}


### PR DESCRIPTION
이 문제는 bfs를 이용하여 연결된 노드들을 모두 탐색하는 문제입니다.

2차원 배열을 통해 양방향 연결 노드를 표현하고, 1번 노드로부터 연결된 노드를 큐에 담습니다.
큐에 담긴 노드를 탐색하며 큐를 pop하고 방문하지 않고 연결이 되어있는 노드를 다시 큐에  담는 식으로 큐에 담긴 노드의 개수를 세주면 풀리는 문제입니다.