### PR TITLE
[Baekjoon-14501] 타임어택 문제풀이

### DIFF
--- a/BOJ/jeongbeen/13_week/퇴사.java
+++ b/BOJ/jeongbeen/13_week/퇴사.java
@@ -1,0 +1,31 @@
+import java.io.*;
+import java.util.*;
+
+public class 퇴사 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int N = Integer.parseInt(br.readLine());
+        String[] s;
+        int[][] arr = new int[N + 1][2];
+        for (int i = 1; i <= N; i++) {
+            s = br.readLine().split(" ");
+            arr[i][0] = Integer.parseInt(s[0]);
+            arr[i][1] = Integer.parseInt(s[1]);
+        }
+        int[] dp = new int[N + 1];
+        for (int i = 1; i <= N; i++) {
+            int max = dp[i - 1];
+            for (int j = 1; j <= i; j++) {
+                if (arr[j][0] + j - 1 == i) {
+                    max = Math.max(max, dp[j - 1] + arr[j][1]);
+                }
+            }
+            dp[i] = max;
+            //bw.write(Arrays.toString(dp) + "\n");
+        }
+        bw.write(dp[N] + "\n");
+        bw.flush();
+    }
+}


### PR DESCRIPTION
N이 최대 15로 크지 않기에 dp라 하긴 좀 부끄러운.. 브루트포스에 가까운 풀이방법 입니다.
현재 날짜도 포함하여 세는 것 때문에 풀 때 헷갈렸네요.
dp[i] 를 dp[1] 부터 dp[i - 1]에서 각 상담 가능한 날짜가 있다면 더해보고 최대값을 비교해서 d[i]에 반영합니다.

선우가 푼 뒤에서부터 본다는 방법을 그땐 깨닫지 못했는데, d[i]를 i날부터 퇴사일까지 최대 금액으로 설정하면 O(N)으로 해결할 수 있을 것 같습니다.