### PR TITLE
[Baekjoon-13549] seulah

### DIFF
--- a/BOJ/seulah/14_week/숨바꼭질 3.py
+++ b/BOJ/seulah/14_week/숨바꼭질 3.py
@@ -1,0 +1,24 @@
+from collections import deque
+
+N,K = map(int,input().split())
+time = [-1]*100001
+
+def bfs(n,k):
+    if n == k:
+        return 0
+    queue = deque([(n)])
+    time[n] = 0
+    while queue:
+        X = queue.popleft()
+        for nx in [X-1,X+1,2*X]:
+            if 0<=nx<=100000 and time[nx] ==-1:
+                if nx == 2*X:
+                    time[nx] = time[X]
+                    queue.appendleft(nx)
+                else:
+                    time[nx] = time[X]+1
+                    queue.append(nx)
+    return time[k]
+
+print(bfs(N,K))
+


### PR DESCRIPTION
### [Baekjoon-13549] 숨바꼭질 3

기존 숨바꼭질(1697번) 문제와 대부분의 흐름은 동일했지만,이 문제에서는 순간이동(2*X)이 0초에 이루어진다는 점이 달랐습니다.

처음에는 단순히`nx`가 `2*X`일 때와`X+1/X-1`일 때로 분기하여 time 배열에 차등 적용하면 된다고 생각했지만,
실제로 구현해보니 순간이동이 0초이기 때문에 기존처럼 **time 배열을 0으로 초기화**하면 방문 여부와 시간 0을 구분할 수 없고,
모든 이동을 `queue.append()`로 처리할 경우 더 빠른 순간이동 경로가 뒤로 밀려 탐색이 늦어지는 문제가 발생했습니다.

기존 문제는 모든 이동이 동일한 시간(1초)으로 이루어졌기 때문에 탐색 순서가 정답에 영향을 주지 않았지만,
이 문제는 이동마다 소요 시간이 달라지므로 **순간이동을 우선적으로 고려**해야한다는 점을 알게되었습니다!_(고마워 지피티야)_

또 생각했던 것은 시간이 0초라 해도 무조건`2*N`하는게 유리할까? 였습니다.
만약 도착지보다 멀어지게 되면 오히려 시간이 더 많이 소요되는 것은 아닐까 생각했지만 
BFS 구조 상 더 빠른 시간에 먼저 도달한 경로만 남게 돼서 비효율적인 경로는 자연스럽게 걸러지니 괜찮다고 하더라구욥 _(고마워 지피티야)_

따라서 이번 풀이에서는 **time 배열을 -1로 초기화**하여 방문 여부와 0초 도달을 명확히 구분하고
**순간이동(2*X)은 `appendleft()`를 사용해 큐의 앞쪽에 넣어 우선 탐색**하도록 하였습니다